### PR TITLE
Make metrics multi-chip aware, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased][unreleased]
+### Changed
+- made metrics aware of multiple chips
+- made metrics also collect power draw
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/bin/metrics-temperature.rb
+++ b/bin/metrics-temperature.rb
@@ -54,7 +54,6 @@ class Sensors < Sensu::Plugin::Metric::CLI::Graphite
 
       # all other lines are metrics
       lines[1..-1].each do |line|
-
         begin
           key, value = line.split(':')
           key = key.downcase.gsub(/\s/, '')

--- a/bin/metrics-temperature.rb
+++ b/bin/metrics-temperature.rb
@@ -58,7 +58,7 @@ class Sensors < Sensu::Plugin::Metric::CLI::Graphite
           key, value = line.split(':')
           key = key.downcase.gsub(/\s/, '')
 
-          if key[0..3] == 'temp' || key[0..3] == 'core' || key[0..2] == 'loc' || key[0..4] == 'power'
+          if key.start_with?('temp', 'core', 'loc', 'power', 'physical')
             value.strip =~ /[\+\-]?(\d+(\.\d)?)/
             value = Regexp.last_match[1]
             key = [chip, key].join('.')


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** yes, issue #4 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Example output

```plain
kronos.sensors.i350bb-pci-8100.loc1 66.0 1489162933
kronos.sensors.power_meter-acpi-0.power1 894.0 1489162933
kronos.sensors.coretemp-isa-0000.core0 29.0 1489162933
kronos.sensors.coretemp-isa-0000.core1 34.0 1489162933
kronos.sensors.coretemp-isa-0000.core2 31.0 1489162933
kronos.sensors.coretemp-isa-0000.core3 28.0 1489162933
kronos.sensors.coretemp-isa-0000.core4 28.0 1489162933
kronos.sensors.coretemp-isa-0000.core8 27.0 1489162933
kronos.sensors.coretemp-isa-0000.core9 28.0 1489162933
kronos.sensors.coretemp-isa-0000.core10 27.0 1489162933
kronos.sensors.coretemp-isa-0000.core11 27.0 1489162933
kronos.sensors.coretemp-isa-0000.core12 27.0 1489162933
kronos.sensors.coretemp-isa-0001.core0 32.0 1489162933
kronos.sensors.coretemp-isa-0001.core1 34.0 1489162933
kronos.sensors.coretemp-isa-0001.core2 34.0 1489162933
kronos.sensors.coretemp-isa-0001.core3 35.0 1489162933
kronos.sensors.coretemp-isa-0001.core4 35.0 1489162933
kronos.sensors.coretemp-isa-0001.core8 32.0 1489162933
kronos.sensors.coretemp-isa-0001.core9 33.0 1489162933
kronos.sensors.coretemp-isa-0001.core10 36.0 1489162933
kronos.sensors.coretemp-isa-0001.core11 37.0 1489162933
kronos.sensors.coretemp-isa-0001.core12 34.0 1489162933
```

#### Known Compatablity Issues
- I don't know for sure whether all versions support the `-A` flag. I looked in the Changelog of `lm-sensors` but could not find any mention when this was introduced, so I assumed it was not a recent change.
- I don't know about all use cases; I've added collecting the power draw in here, but for people who simply put all of the values into a graph without filtering before, those will wonder why there is one value which is much, much higher than the others.