### PR TITLE
Ditch unnecessary print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- `check-temperature.rb`: removed unnecessary `print`
 
 ## [1.1.0] - 2017-05-17
 - add temperature check (@holygits)

--- a/bin/check-temperature.rb
+++ b/bin/check-temperature.rb
@@ -71,7 +71,6 @@ class CheckTemperature < Sensu::Plugin::Check::CLI
       end
     end
     metrics.each do |k, v|
-      print(v)
       current, high, critical = v
       if current > critical
         @crit_temp << "#{k} has exceeded CRITICAL temperature @ #{current}°C"


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] ~Update README with any necessary configuration snippets~

- [x] ~Binstubs are created if needed~

- [x] RuboCop passes (it passes on the line i've removed 😄 )

- [x] ~Existing tests pass~

#### Purpose

An unnecessary print of the sensor values prevented that the check output starts with `OK`, `WARNING` or `CRITICAL`.

#### Known Compatablity Issues

