### PR TITLE
Update metrics-temperature.rb

### DIFF
--- a/bin/metrics-temperature.rb
+++ b/bin/metrics-temperature.rb
@@ -56,15 +56,17 @@ class Sensors < Sensu::Plugin::Metric::CLI::Graphite
       # all other lines are metrics
       lines[1..-1].each do |line|
         begin
-          key, value = line.split(':')
-          key = key.downcase.gsub(/\s/, '')
-
-          if key.start_with?('temp', 'core', 'loc', 'power', 'physical', 'packageid')
-            value.strip =~ /[\+\-]?(\d+(\.\d)?)/
-            value = Regexp.last_match[1]
-            key = [chip, key].join('.')
-            metrics[key] = value
+          if line.include? ":"
+            key, value = line.split(':')
+            key = key.downcase.gsub(/\s/, '')
+          else
+            next
           end
+
+          value.strip =~ /[\+\-]?(\d+(\.\d)?)/
+          value = Regexp.last_match[1]
+          key = [chip, key].join('.')
+          metrics[key] = value
         rescue StandardError
           print "malformed section from sensors: #{line}" + "\n"
         end


### PR DESCRIPTION
Checking `key.start_with` is not a good way to identify malformed lines. It may leave out may lines of valid output. See this output:

```
# sensors -A
atk0110-acpi-0
Vcore Voltage:      +1.26 V  (min =  +0.80 V, max =  +1.60 V)
+3.3V Voltage:      +3.25 V  (min =  +2.97 V, max =  +3.63 V)
+5V Voltage:        +5.01 V  (min =  +4.50 V, max =  +5.50 V)
+12V Voltage:      +11.95 V  (min = +10.20 V, max = +13.80 V)
CPU Fan Speed:     3325 RPM  (min =  600 RPM, max = 7200 RPM)
Chassis Fan Speed:  957 RPM  (min =  600 RPM, max = 7200 RPM)
CPU Temperature:    +84.0°C  (high = +60.0°C, crit = +95.0°C)
MB Temperature:     +44.0°C  (high = +45.0°C, crit = +75.0°C)

k10temp-pci-00c3
temp1:        +82.0°C  (high = +70.0°C)
                       (crit = +83.5°C, hyst = +80.5°C)

fam15h_power-pci-00c4
power1:       96.64 W  (crit =  95.06 W)

```

The current version of the plugin will miss the whole first section.

Instead, just check if the `:` character is present in that line. If it is, then split by key/value. If it isn't, then skip to next line.

If the split occurs, then parse all lines regardless of the string they begin with.

The proposed version parses the example output shown above correctly.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
