### PR TITLE
Create metrics-temperature-rpi.rb

### DIFF
--- a/bin/metrics-temperature-rpi.rb
+++ b/bin/metrics-temperature-rpi.rb
@@ -1,0 +1,70 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+#   <script name>
+#
+# DESCRIPTION:
+#   This plugin uses sensors to collect basic system metrics on a
+#   Raspberry Pi. It produces Graphite formated output.
+
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: socket
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2019 Florin Andrei <florin@andrei.myip.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'socket'
+
+#
+# Sensors
+#
+class Sensors < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to .$parent.$child',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.sensors"
+
+  def run
+    raw = `vcgencmd measure_temp`
+    lines = raw.split("\n")
+    metrics = {}
+
+    lines.each do |line|
+      begin
+        if line.include? "="
+          key, value = line.split('=')
+          key = key.downcase.gsub(/\s/, '')
+        else
+          next
+        end
+
+        value.strip =~ /[\+\-]?(\d+(\.\d)?)/
+        value = Regexp.last_match[1]
+        metrics[key] = value
+      rescue StandardError
+        print "malformed section from sensors: #{line}" + "\n"
+      end
+    end
+    timestamp = Time.now.to_i
+    metrics.each do |key, value|
+      output [config[:scheme], key].join('.'), value, timestamp
+    end
+    ok
+  end
+end


### PR DESCRIPTION
Plugin for Raspberry Pi / Raspbian OS. It only measures CPU temperature on this platform, nothing else.
It is based on the generic `metrics-temperature.rb` plugin.
It uses the output from this command (specific to the RPi) to determine the temperature:

```
# vcgencmd measure_temp
temp=53.2'C
```

Verified on Raspbian GNU/Linux 9 (stretch) / Raspberry Pi 3 Model B.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
